### PR TITLE
Update nlb.tf

### DIFF
--- a/nlb.tf
+++ b/nlb.tf
@@ -40,7 +40,7 @@ resource "random_string" "alb_prefix" {
 }
 
 resource "aws_lb_target_group" "ecs_default" {
-  name                 = substr("ecs-${var.name}-default-${random_string.alb_prefix.result}", 0, 32)
+  name                 = substr("ecs-${var.name}-${random_string.alb_prefix.result}", 0, 32)
   port                 = 1194
   protocol             = "TCP"
   vpc_id               = var.vpc_id


### PR DESCRIPTION
Remove the word default from aws_lb_target_group name to make the name smaller, have problem if have var.name = shared-services-vpn, for example.

The error:
Error: "name" cannot end with a hyphen

  on .terraform/modules/openvpn/nlb.tf line 43, in resource "aws_lb_target_group" "ecs_default":
  43:   name                 = substr("ecs-${var.name}-default-${random_string.alb_prefix.result}", 0, 32)