### PR TITLE
🐛 Fix error when deleteing ecs cluster

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -9,5 +9,12 @@ resource "aws_ecs_cluster" "ecs" {
     ]
   }
 
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+    aws autoscaling update-auto-scaling-group --auto-scaling-group-name ecs-${self.name} --min-size 0 --desired-capacity 0
+EOT
+  }
+
 }
 

--- a/s3.tf
+++ b/s3.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket_acl" "vpn" {
   depends_on = [aws_s3_bucket_ownership_controls.vpn]
 
   bucket = aws_s3_bucket.vpn.id
-  acl = "private"
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_ownership_controls" "vpn" {
@@ -17,9 +17,9 @@ resource "aws_s3_bucket_ownership_controls" "vpn" {
 }
 
 resource "aws_s3_bucket_policy" "vpn" {
-  count = var.s3_bucket_policy != "" ? 1 : 0
+  count  = var.s3_bucket_policy != "" ? 1 : 0
   bucket = aws_s3_bucket.vpn.id
-  policy        = var.s3_bucket_policy
+  policy = var.s3_bucket_policy
 }
 
 resource "aws_s3_bucket_public_access_block" "vpn" {


### PR DESCRIPTION
ecs can't be deleted because the ec2 stil atachhed. To fix the issue we change the capacity of the cluster


